### PR TITLE
Add currency list and sick leave summary

### DIFF
--- a/lib/core/constants/currency_constants.dart
+++ b/lib/core/constants/currency_constants.dart
@@ -1,11 +1,494 @@
 class CurrencyConstants {
   static const List<String> supportedCurrencies = [
-    'BHD',
-    'USD',
-    'EUR',
-    'GBP',
-    'JPY',
-    'CAD',
-    'AUD'
+    'AED', // United Arab Emirates Dirham
+    'AFN', // Afghan Afghani
+    'ALL', // Albanian Lek
+    'AMD', // Armenian Dram
+    'ANG', // Netherlands Antillean Guilder
+    'AOA', // Angolan Kwanza
+    'ARS', // Argentine Peso
+    'AUD', // Australian Dollar
+    'AWG', // Aruban Florin
+    'AZN', // Azerbaijani Manat
+    'BAM', // Bosnia-Herzegovina Convertible Mark
+    'BBD', // Barbadian Dollar
+    'BDT', // Bangladeshi Taka
+    'BGN', // Bulgarian Lev
+    'BHD', // Bahraini Dinar
+    'BIF', // Burundian Franc
+    'BMD', // Bermudian Dollar
+    'BND', // Brunei Dollar
+    'BOB', // Bolivian Boliviano
+    'BRL', // Brazilian Real
+    'BSD', // Bahamian Dollar
+    'BTN', // Bhutanese Ngultrum
+    'BWP', // Botswanan Pula
+    'BYN', // Belarusian Ruble
+    'BZD', // Belize Dollar
+    'CAD', // Canadian Dollar
+    'CDF', // Congolese Franc
+    'CHF', // Swiss Franc
+    'CLP', // Chilean Peso
+    'CNY', // Chinese Yuan
+    'COP', // Colombian Peso
+    'CRC', // Costa Rican Colón
+    'CUP', // Cuban Peso
+    'CVE', // Cape Verdean Escudo
+    'CZK', // Czech Koruna
+    'DJF', // Djiboutian Franc
+    'DKK', // Danish Krone
+    'DOP', // Dominican Peso
+    'DZD', // Algerian Dinar
+    'EGP', // Egyptian Pound
+    'ERN', // Eritrean Nakfa
+    'ETB', // Ethiopian Birr
+    'EUR', // Euro
+    'FJD', // Fijian Dollar
+    'FKP', // Falkland Islands Pound
+    'GBP', // British Pound Sterling
+    'GEL', // Georgian Lari
+    'GHS', // Ghanaian Cedi
+    'GIP', // Gibraltar Pound
+    'GMD', // Gambian Dalasi
+    'GNF', // Guinean Franc
+    'GTQ', // Guatemalan Quetzal
+    'GYD', // Guyanese Dollar
+    'HKD', // Hong Kong Dollar
+    'HNL', // Honduran Lempira
+    'HRK', // Croatian Kuna
+    'HTG', // Haitian Gourde
+    'HUF', // Hungarian Forint
+    'IDR', // Indonesian Rupiah
+    'ILS', // Israeli New Sheqel
+    'INR', // Indian Rupee
+    'IQD', // Iraqi Dinar
+    'IRR', // Iranian Rial
+    'ISK', // Icelandic Króna
+    'JMD', // Jamaican Dollar
+    'JOD', // Jordanian Dinar
+    'JPY', // Japanese Yen
+    'KES', // Kenyan Shilling
+    'KGS', // Kyrgystani Som
+    'KHR', // Cambodian Riel
+    'KMF', // Comorian Franc
+    'KPW', // North Korean Won
+    'KRW', // South Korean Won
+    'KWD', // Kuwaiti Dinar
+    'KYD', // Cayman Islands Dollar
+    'KZT', // Kazakhstani Tenge
+    'LAK', // Laotian Kip
+    'LBP', // Lebanese Pound
+    'LKR', // Sri Lankan Rupee
+    'LRD', // Liberian Dollar
+    'LSL', // Lesotho Loti
+    'LYD', // Libyan Dinar
+    'MAD', // Moroccan Dirham
+    'MDL', // Moldovan Leu
+    'MGA', // Malagasy Ariary
+    'MKD', // Macedonian Denar
+    'MMK', // Myanma Kyat
+    'MNT', // Mongolian Tugrik
+    'MOP', // Macanese Pataca
+    'MRU', // Mauritanian Ouguiya
+    'MUR', // Mauritian Rupee
+    'MVR', // Maldivian Rufiyaa
+    'MWK', // Malawian Kwacha
+    'MXN', // Mexican Peso
+    'MYR', // Malaysian Ringgit
+    'MZN', // Mozambican Metical
+    'NAD', // Namibian Dollar
+    'NGN', // Nigerian Naira
+    'NIO', // Nicaraguan Córdoba
+    'NOK', // Norwegian Krone
+    'NPR', // Nepalese Rupee
+    'NZD', // New Zealand Dollar
+    'OMR', // Omani Rial
+    'PAB', // Panamanian Balboa
+    'PEN', // Peruvian Nuevo Sol
+    'PGK', // Papua New Guinean Kina
+    'PHP', // Philippine Peso
+    'PKR', // Pakistani Rupee
+    'PLN', // Polish Zloty
+    'PYG', // Paraguayan Guarani
+    'QAR', // Qatari Rial
+    'RON', // Romanian Leu
+    'RSD', // Serbian Dinar
+    'RUB', // Russian Ruble
+    'RWF', // Rwandan Franc
+    'SAR', // Saudi Riyal
+    'SBD', // Solomon Islands Dollar
+    'SCR', // Seychellois Rupee
+    'SDG', // Sudanese Pound
+    'SEK', // Swedish Krona
+    'SGD', // Singapore Dollar
+    'SHP', // Saint Helena Pound
+    'SLE', // Sierra Leonean Leone
+    'SLL', // Sierra Leonean Leone (old)
+    'SOS', // Somali Shilling
+    'SRD', // Surinamese Dollar
+    'STN', // São Tomé and Príncipe Dobra
+    'SYP', // Syrian Pound
+    'SZL', // Swazi Lilangeni
+    'THB', // Thai Baht
+    'TJS', // Tajikistani Somoni
+    'TMT', // Turkmenistani Manat
+    'TND', // Tunisian Dinar
+    'TOP', // Tongan Pa'anga
+    'TRY', // Turkish Lira
+    'TTD', // Trinidad and Tobago Dollar
+    'TVD', // Tuvaluan Dollar
+    'TWD', // New Taiwan Dollar
+    'TZS', // Tanzanian Shilling
+    'UAH', // Ukrainian Hryvnia
+    'UGX', // Ugandan Shilling
+    'USD', // US Dollar
+    'UYU', // Uruguayan Peso
+    'UZS', // Uzbekistan Som
+    'VED', // Venezuelan Bolívar Digital
+    'VES', // Venezuelan Bolívar Soberano
+    'VND', // Vietnamese Dong
+    'VUV', // Vanuatu Vatu
+    'WST', // Samoan Tala
+    'XAF', // CFA Franc BEAC
+    'XCD', // East Caribbean Dollar
+    'XDR', // Special Drawing Rights
+    'XOF', // CFA Franc BCEAO
+    'XPF', // CFP Franc
+    'YER', // Yemeni Rial
+    'ZAR', // South African Rand
+    'ZMW', // Zambian Kwacha
+    'ZWL', // Zimbabwean Dollar
   ];
+
+  // Currency symbols mapping
+  static const Map<String, String> currencySymbols = {
+    'AED': 'د.إ',
+    'AFN': '؋',
+    'ALL': 'L',
+    'AMD': '֏',
+    'ANG': 'ƒ',
+    'AOA': 'Kz',
+    'ARS': '\$',
+    'AUD': 'A\$',
+    'AWG': 'ƒ',
+    'AZN': '₼',
+    'BAM': 'КМ',
+    'BBD': 'Bds\$',
+    'BDT': '৳',
+    'BGN': 'лв',
+    'BHD': '.د.ب',
+    'BIF': 'FBu',
+    'BMD': 'BD\$',
+    'BND': 'B\$',
+    'BOB': 'Bs',
+    'BRL': 'R\$',
+    'BSD': 'B\$',
+    'BTN': 'Nu.',
+    'BWP': 'P',
+    'BYN': 'Br',
+    'BZD': 'BZ\$',
+    'CAD': 'C\$',
+    'CDF': 'FC',
+    'CHF': 'CHF',
+    'CLP': '\$',
+    'CNY': '¥',
+    'COP': '\$',
+    'CRC': '₡',
+    'CUP': '\$',
+    'CVE': '\$',
+    'CZK': 'Kč',
+    'DJF': 'Fdj',
+    'DKK': 'kr',
+    'DOP': 'RD\$',
+    'DZD': 'د.ج',
+    'EGP': '£',
+    'ERN': 'Nfk',
+    'ETB': 'Br',
+    'EUR': '€',
+    'FJD': 'FJ\$',
+    'FKP': '£',
+    'GBP': '£',
+    'GEL': '₾',
+    'GHS': '₵',
+    'GIP': '£',
+    'GMD': 'D',
+    'GNF': 'FG',
+    'GTQ': 'Q',
+    'GYD': 'G\$',
+    'HKD': 'HK\$',
+    'HNL': 'L',
+    'HRK': 'kn',
+    'HTG': 'G',
+    'HUF': 'Ft',
+    'IDR': 'Rp',
+    'ILS': '₪',
+    'INR': '₹',
+    'IQD': 'ع.د',
+    'IRR': '﷼',
+    'ISK': 'kr',
+    'JMD': 'J\$',
+    'JOD': 'د.ا',
+    'JPY': '¥',
+    'KES': 'KSh',
+    'KGS': 'лв',
+    'KHR': '៛',
+    'KMF': 'CF',
+    'KPW': '₩',
+    'KRW': '₩',
+    'KWD': 'د.ك',
+    'KYD': 'CI\$',
+    'KZT': '₸',
+    'LAK': '₭',
+    'LBP': 'ل.ل',
+    'LKR': '₨',
+    'LRD': 'L\$',
+    'LSL': 'L',
+    'LYD': 'ل.د',
+    'MAD': 'د.م.',
+    'MDL': 'L',
+    'MGA': 'Ar',
+    'MKD': 'ден',
+    'MMK': 'K',
+    'MNT': '₮',
+    'MOP': 'MOP\$',
+    'MRU': 'UM',
+    'MUR': '₨',
+    'MVR': '.ރ',
+    'MWK': 'MK',
+    'MXN': '\$',
+    'MYR': 'RM',
+    'MZN': 'MT',
+    'NAD': 'N\$',
+    'NGN': '₦',
+    'NIO': 'C\$',
+    'NOK': 'kr',
+    'NPR': '₨',
+    'NZD': 'NZ\$',
+    'OMR': '﷼',
+    'PAB': 'B/.',
+    'PEN': 'S/',
+    'PGK': 'K',
+    'PHP': '₱',
+    'PKR': '₨',
+    'PLN': 'zł',
+    'PYG': '₲',
+    'QAR': '﷼',
+    'RON': 'lei',
+    'RSD': 'Дин.',
+    'RUB': '₽',
+    'RWF': 'RF',
+    'SAR': '﷼',
+    'SBD': 'SI\$',
+    'SCR': '₨',
+    'SDG': 'ج.س.',
+    'SEK': 'kr',
+    'SGD': 'S\$',
+    'SHP': '£',
+    'SLE': 'Le',
+    'SLL': 'Le',
+    'SOS': 'S',
+    'SRD': 'Sr\$',
+    'STN': 'Db',
+    'SYP': '£',
+    'SZL': 'E',
+    'THB': '฿',
+    'TJS': 'SM',
+    'TMT': 'T',
+    'TND': 'د.ت',
+    'TOP': 'T\$',
+    'TRY': '₺',
+    'TTD': 'TT\$',
+    'TVD': 'TV\$',
+    'TWD': 'NT\$',
+    'TZS': 'TSh',
+    'UAH': '₴',
+    'UGX': 'USh',
+    'USD': '\$',
+    'UYU': '\$U',
+    'UZS': 'лв',
+    'VED': 'Bs.S',
+    'VES': 'Bs.S',
+    'VND': '₫',
+    'VUV': 'Vt',
+    'WST': 'WS\$',
+    'XAF': 'FCFA',
+    'XCD': 'EC\$',
+    'XDR': 'SDR',
+    'XOF': 'CFA',
+    'XPF': '₣',
+    'YER': '﷼',
+    'ZAR': 'R',
+    'ZMW': 'ZK',
+    'ZWL': 'Z\$',
+  };
+
+  // Get currency symbol by code
+  static String getCurrencySymbol(String currencyCode) {
+    return currencySymbols[currencyCode] ?? currencyCode;
+  }
+
+  // Get currency name by code
+  static String getCurrencyName(String currencyCode) {
+    switch (currencyCode) {
+      case 'AED': return 'United Arab Emirates Dirham';
+      case 'AFN': return 'Afghan Afghani';
+      case 'ALL': return 'Albanian Lek';
+      case 'AMD': return 'Armenian Dram';
+      case 'ANG': return 'Netherlands Antillean Guilder';
+      case 'AOA': return 'Angolan Kwanza';
+      case 'ARS': return 'Argentine Peso';
+      case 'AUD': return 'Australian Dollar';
+      case 'AWG': return 'Aruban Florin';
+      case 'AZN': return 'Azerbaijani Manat';
+      case 'BAM': return 'Bosnia-Herzegovina Convertible Mark';
+      case 'BBD': return 'Barbadian Dollar';
+      case 'BDT': return 'Bangladeshi Taka';
+      case 'BGN': return 'Bulgarian Lev';
+      case 'BHD': return 'Bahraini Dinar';
+      case 'BIF': return 'Burundian Franc';
+      case 'BMD': return 'Bermudian Dollar';
+      case 'BND': return 'Brunei Dollar';
+      case 'BOB': return 'Bolivian Boliviano';
+      case 'BRL': return 'Brazilian Real';
+      case 'BSD': return 'Bahamian Dollar';
+      case 'BTN': return 'Bhutanese Ngultrum';
+      case 'BWP': return 'Botswanan Pula';
+      case 'BYN': return 'Belarusian Ruble';
+      case 'BZD': return 'Belize Dollar';
+      case 'CAD': return 'Canadian Dollar';
+      case 'CDF': return 'Congolese Franc';
+      case 'CHF': return 'Swiss Franc';
+      case 'CLP': return 'Chilean Peso';
+      case 'CNY': return 'Chinese Yuan';
+      case 'COP': return 'Colombian Peso';
+      case 'CRC': return 'Costa Rican Colón';
+      case 'CUP': return 'Cuban Peso';
+      case 'CVE': return 'Cape Verdean Escudo';
+      case 'CZK': return 'Czech Koruna';
+      case 'DJF': return 'Djiboutian Franc';
+      case 'DKK': return 'Danish Krone';
+      case 'DOP': return 'Dominican Peso';
+      case 'DZD': return 'Algerian Dinar';
+      case 'EGP': return 'Egyptian Pound';
+      case 'ERN': return 'Eritrean Nakfa';
+      case 'ETB': return 'Ethiopian Birr';
+      case 'EUR': return 'Euro';
+      case 'FJD': return 'Fijian Dollar';
+      case 'FKP': return 'Falkland Islands Pound';
+      case 'GBP': return 'British Pound Sterling';
+      case 'GEL': return 'Georgian Lari';
+      case 'GHS': return 'Ghanaian Cedi';
+      case 'GIP': return 'Gibraltar Pound';
+      case 'GMD': return 'Gambian Dalasi';
+      case 'GNF': return 'Guinean Franc';
+      case 'GTQ': return 'Guatemalan Quetzal';
+      case 'GYD': return 'Guyanese Dollar';
+      case 'HKD': return 'Hong Kong Dollar';
+      case 'HNL': return 'Honduran Lempira';
+      case 'HRK': return 'Croatian Kuna';
+      case 'HTG': return 'Haitian Gourde';
+      case 'HUF': return 'Hungarian Forint';
+      case 'IDR': return 'Indonesian Rupiah';
+      case 'ILS': return 'Israeli New Sheqel';
+      case 'INR': return 'Indian Rupee';
+      case 'IQD': return 'Iraqi Dinar';
+      case 'IRR': return 'Iranian Rial';
+      case 'ISK': return 'Icelandic Króna';
+      case 'JMD': return 'Jamaican Dollar';
+      case 'JOD': return 'Jordanian Dinar';
+      case 'JPY': return 'Japanese Yen';
+      case 'KES': return 'Kenyan Shilling';
+      case 'KGS': return 'Kyrgystani Som';
+      case 'KHR': return 'Cambodian Riel';
+      case 'KMF': return 'Comorian Franc';
+      case 'KPW': return 'North Korean Won';
+      case 'KRW': return 'South Korean Won';
+      case 'KWD': return 'Kuwaiti Dinar';
+      case 'KYD': return 'Cayman Islands Dollar';
+      case 'KZT': return 'Kazakhstani Tenge';
+      case 'LAK': return 'Laotian Kip';
+      case 'LBP': return 'Lebanese Pound';
+      case 'LKR': return 'Sri Lankan Rupee';
+      case 'LRD': return 'Liberian Dollar';
+      case 'LSL': return 'Lesotho Loti';
+      case 'LYD': return 'Libyan Dinar';
+      case 'MAD': return 'Moroccan Dirham';
+      case 'MDL': return 'Moldovan Leu';
+      case 'MGA': return 'Malagasy Ariary';
+      case 'MKD': return 'Macedonian Denar';
+      case 'MMK': return 'Myanma Kyat';
+      case 'MNT': return 'Mongolian Tugrik';
+      case 'MOP': return 'Macanese Pataca';
+      case 'MRU': return 'Mauritanian Ouguiya';
+      case 'MUR': return 'Mauritian Rupee';
+      case 'MVR': return 'Maldivian Rufiyaa';
+      case 'MWK': return 'Malawian Kwacha';
+      case 'MXN': return 'Mexican Peso';
+      case 'MYR': return 'Malaysian Ringgit';
+      case 'MZN': return 'Mozambican Metical';
+      case 'NAD': return 'Namibian Dollar';
+      case 'NGN': return 'Nigerian Naira';
+      case 'NIO': return 'Nicaraguan Córdoba';
+      case 'NOK': return 'Norwegian Krone';
+      case 'NPR': return 'Nepalese Rupee';
+      case 'NZD': return 'New Zealand Dollar';
+      case 'OMR': return 'Omani Rial';
+      case 'PAB': return 'Panamanian Balboa';
+      case 'PEN': return 'Peruvian Nuevo Sol';
+      case 'PGK': return 'Papua New Guinean Kina';
+      case 'PHP': return 'Philippine Peso';
+      case 'PKR': return 'Pakistani Rupee';
+      case 'PLN': return 'Polish Zloty';
+      case 'PYG': return 'Paraguayan Guarani';
+      case 'QAR': return 'Qatari Rial';
+      case 'RON': return 'Romanian Leu';
+      case 'RSD': return 'Serbian Dinar';
+      case 'RUB': return 'Russian Ruble';
+      case 'RWF': return 'Rwandan Franc';
+      case 'SAR': return 'Saudi Riyal';
+      case 'SBD': return 'Solomon Islands Dollar';
+      case 'SCR': return 'Seychellois Rupee';
+      case 'SDG': return 'Sudanese Pound';
+      case 'SEK': return 'Swedish Krona';
+      case 'SGD': return 'Singapore Dollar';
+      case 'SHP': return 'Saint Helena Pound';
+      case 'SLE': return 'Sierra Leonean Leone';
+      case 'SLL': return 'Sierra Leonean Leone (old)';
+      case 'SOS': return 'Somali Shilling';
+      case 'SRD': return 'Surinamese Dollar';
+      case 'STN': return 'São Tomé and Príncipe Dobra';
+      case 'SYP': return 'Syrian Pound';
+      case 'SZL': return 'Swazi Lilangeni';
+      case 'THB': return 'Thai Baht';
+      case 'TJS': return 'Tajikistani Somoni';
+      case 'TMT': return 'Turkmenistani Manat';
+      case 'TND': return 'Tunisian Dinar';
+      case 'TOP': return 'Tongan Pa\'anga';
+      case 'TRY': return 'Turkish Lira';
+      case 'TTD': return 'Trinidad and Tobago Dollar';
+      case 'TVD': return 'Tuvaluan Dollar';
+      case 'TWD': return 'New Taiwan Dollar';
+      case 'TZS': return 'Tanzanian Shilling';
+      case 'UAH': return 'Ukrainian Hryvnia';
+      case 'UGX': return 'Ugandan Shilling';
+      case 'USD': return 'US Dollar';
+      case 'UYU': return 'Uruguayan Peso';
+      case 'UZS': return 'Uzbekistan Som';
+      case 'VED': return 'Venezuelan Bolívar Digital';
+      case 'VES': return 'Venezuelan Bolívar Soberano';
+      case 'VND': return 'Vietnamese Dong';
+      case 'VUV': return 'Vanuatu Vatu';
+      case 'WST': return 'Samoan Tala';
+      case 'XAF': return 'CFA Franc BEAC';
+      case 'XCD': return 'East Caribbean Dollar';
+      case 'XDR': return 'Special Drawing Rights';
+      case 'XOF': return 'CFA Franc BCEAO';
+      case 'XPF': return 'CFP Franc';
+      case 'YER': return 'Yemeni Rial';
+      case 'ZAR': return 'South African Rand';
+      case 'ZMW': return 'Zambian Kwacha';
+      case 'ZWL': return 'Zimbabwean Dollar';
+      default: return currencyCode;
+    }
+  }
 } 

--- a/lib/data/local/hive_db.dart
+++ b/lib/data/local/hive_db.dart
@@ -1423,4 +1423,61 @@ class HiveDb {
     }
   }
 
+  // Get count of sick leaves for the current year
+  static int getSickLeavesThisYear() {
+    try {
+      final now = DateTime.now();
+      final yearStart = DateTime(now.year, 1, 1);
+      final yearEnd = DateTime(now.year, 12, 31);
+      
+      final allEntries = getAllEntries();
+      int sickLeaveCount = 0;
+      
+      for (var day = yearStart; day.isBefore(yearEnd.add(const Duration(days: 1))); day = day.add(const Duration(days: 1))) {
+        final dateKey = DateFormat('yyyy-MM-dd').format(day);
+        final entry = allEntries[dateKey];
+        
+        if (entry != null && entry['offDay'] == true) {
+          final description = entry['description'] as String?;
+          if (description != null && description.toLowerCase().contains('sick')) {
+            sickLeaveCount++;
+          }
+        }
+      }
+      
+      return sickLeaveCount;
+    } catch (e) {
+      debugPrint('Error getting sick leaves count: $e');
+      return 0;
+    }
+  }
+
+  // Get count of sick leaves for a specific year
+  static int getSickLeavesForYear(int year) {
+    try {
+      final yearStart = DateTime(year, 1, 1);
+      final yearEnd = DateTime(year, 12, 31);
+      
+      final allEntries = getAllEntries();
+      int sickLeaveCount = 0;
+      
+      for (var day = yearStart; day.isBefore(yearEnd.add(const Duration(days: 1))); day = day.add(const Duration(days: 1))) {
+        final dateKey = DateFormat('yyyy-MM-dd').format(day);
+        final entry = allEntries[dateKey];
+        
+        if (entry != null && entry['offDay'] == true) {
+          final description = entry['description'] as String?;
+          if (description != null && description.toLowerCase().contains('sick')) {
+            sickLeaveCount++;
+          }
+        }
+      }
+      
+      return sickLeaveCount;
+    } catch (e) {
+      debugPrint('Error getting sick leaves count for year $year: $e');
+      return 0;
+    }
+  }
+
 }

--- a/lib/features/summary/presentation/screens/summary_screen.dart
+++ b/lib/features/summary/presentation/screens/summary_screen.dart
@@ -10,6 +10,7 @@ import '../../../../data/repositories/work_hours_repository.dart';
 import '../../summary_controller.dart';
 import 'package:provider/provider.dart';
 import '../../../../core/constants/app_constants.dart';
+import '../widgets/summary_widgets.dart';
 
 // Data model for chart
 class WorkHoursData {
@@ -381,6 +382,8 @@ class _SummaryScreenState extends State<SummaryScreen> {
                           _buildWeeklyBarChart(),
                           const SizedBox(height: 24),
                           _buildLastMonthSummaryCard(summary, lastMonthName),
+                          const SizedBox(height: 24),
+                          const SickLeavesWidget(),
                         ],
                       ),
                     ),

--- a/lib/features/summary/presentation/widgets/summary_widgets.dart
+++ b/lib/features/summary/presentation/widgets/summary_widgets.dart
@@ -461,3 +461,135 @@ class MonthlySummaryCard extends StatelessWidget {
     );
   }
 }
+
+class SickLeavesWidget extends StatelessWidget {
+  const SickLeavesWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final currentYear = DateTime.now().year;
+    final sickLeavesCount = HiveDb.getSickLeavesThisYear();
+    
+    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+    final textColor = isDarkMode ? Colors.white : Colors.black;
+    final subTextColor = isDarkMode ? Colors.white70 : Colors.grey[600];
+
+    return Card(
+      elevation: 4,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  children: [
+                    Icon(
+                      Icons.sick_outlined,
+                      color: Colors.orange,
+                      size: 24,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      'Sick Leaves This Year',
+                      style: TextStyle(
+                        color: textColor,
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: sickLeavesCount > 0 
+                        ? Colors.orange.withOpacity(0.1)
+                        : Colors.green.withOpacity(0.1),
+                    borderRadius: BorderRadius.circular(20),
+                    border: Border.all(
+                      color: sickLeavesCount > 0 
+                          ? Colors.orange.withOpacity(0.3)
+                          : Colors.green.withOpacity(0.3),
+                    ),
+                  ),
+                  child: Text(
+                    '$sickLeavesCount',
+                    style: TextStyle(
+                      color: sickLeavesCount > 0 ? Colors.orange : Colors.green,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 18,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: isDarkMode 
+                    ? Colors.grey[800]!.withOpacity(0.5) 
+                    : Colors.grey[100],
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Year: $currentYear',
+                    style: TextStyle(
+                      color: subTextColor,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    sickLeavesCount == 0 
+                        ? 'No sick leaves taken this year'
+                        : sickLeavesCount == 1 
+                            ? '1 sick leave taken this year'
+                            : '$sickLeavesCount sick leaves taken this year',
+                    style: TextStyle(
+                      color: textColor,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  if (sickLeavesCount > 0) ...[
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.info_outline,
+                          color: Colors.orange,
+                          size: 16,
+                        ),
+                        const SizedBox(width: 6),
+                        Expanded(
+                          child: Text(
+                            'Sick leaves are tracked as off days with "sick" in the description',
+                            style: TextStyle(
+                              color: subTextColor,
+                              fontSize: 12,
+                              fontStyle: FontStyle.italic,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Add a comprehensive list of currencies and a new widget to display the number of sick leaves taken this year on the summary page.

---
<a href="https://cursor.com/background-agent?bcId=bc-8056c468-65bd-4ac6-9923-065fc2d2b4dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8056c468-65bd-4ac6-9923-065fc2d2b4dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

